### PR TITLE
Revert "Revert "Ported tests to plone.app.testing""

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Plone',
+        'Framework :: Plone :: 5.0',
         'Framework :: Zope2',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
@@ -20,6 +21,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 5.0',
     ],
     keywords='folder btree order plone archetypes atcontenttypes',
     author='Plone Foundation',
@@ -48,7 +50,6 @@ setup(
         ],
         'test': [
             'plone.app.testing',
-            'Products.PloneTestCase',
         ],
     },
 )

--- a/src/plone/app/folder/tests/base.py
+++ b/src/plone/app/folder/tests/base.py
@@ -1,22 +1,19 @@
 # -*- coding: utf-8 -*-
-from Products.PloneTestCase import PloneTestCase as ptc
-from Products.Five.testbrowser import Browser
-
-ptc.setupPloneSite()
-
-
-class IntegrationTestCase(ptc.PloneTestCase):
-    """ base class for integration tests """
+from plone.app.testing.bbb import PloneTestCase
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+from plone.testing.z2 import Browser
 
 
-class FunctionalTestCase(ptc.FunctionalTestCase):
+class FunctionalTestCase(PloneTestCase):
     """ base class for functional tests """
 
     def getBrowser(self, loggedIn=True):
         """ instantiate and return a testbrowser for convenience """
-        browser = Browser()
+        browser = Browser(self.layer['app'])
         if loggedIn:
-            user = ptc.default_user
-            pwd = ptc.default_password
-            browser.addHeader('Authorization', 'Basic %s:%s' % (user, pwd))
+            browser.addHeader('Authorization', 'Basic %s:%s' % (
+                TEST_USER_NAME, TEST_USER_PASSWORD))
         return browser
+
+IntegrationTestCase = FunctionalTestCase

--- a/src/plone/app/folder/tests/benchmarks.py
+++ b/src/plone/app/folder/tests/benchmarks.py
@@ -4,7 +4,7 @@
 # to run individual tests using:
 # $ bin/test -s plone.app.folder --tests-pattern=benchmarks -t <testName>
 # where <testName> is something like "testObjectValuesOrdered"
-from Products.PloneTestCase import PloneTestCase as ptc
+from plone.app.testing.bbb import PloneTestCase
 from Testing import ZopeTestCase as ztc
 from plone.app.folder.tests.content import _createObjectByType
 from plone.app.folder.tests.content import create as createNonBTreeFolder
@@ -13,8 +13,6 @@ from plone.batching.batch import QuantumBatch as Batch
 from profilehooks import timecall
 from random import randint
 from transaction import commit
-from unittest import defaultTestLoader
-from unittest import main
 
 # setup plone site
 ptc.setupPloneSite()
@@ -23,7 +21,7 @@ ptc.setupPloneSite()
 SIZE = 500
 
 
-class TestBenchmarkCase(ptc.PloneTestCase):
+class TestBenchmarkCase(PloneTestCase):
 
     class layer(IntegrationLayer):
 
@@ -176,10 +174,3 @@ class TestBenchmarkCase(ptc.PloneTestCase):
     def testRandomOrdered(self):
         for x in range(1000):
             self.ordered['doc.%d' % randint(0, SIZE-1)]
-
-
-def test_suite():
-    return defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    main(defaultTest='test_suite')

--- a/src/plone/app/folder/tests/layer.py
+++ b/src/plone/app/folder/tests/layer.py
@@ -1,60 +1,45 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
-from Products.PloneTestCase.layer import PloneSite
-from Testing.ZopeTestCase import app
-from Testing.ZopeTestCase import close
-from Testing.ZopeTestCase import installPackage
+from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import applyProfile
+from plone.app.testing.bbb import PTC_FUNCTIONAL_TESTING
+
 from plone.folder.partial import PartialOrdering
-from transaction import commit
+
 from zope.component import provideAdapter
 
-# BBB Zope 2.12
-try:
-    from Zope2.App.zcml import load_config
-    load_config  # pyflakes
-    from OFS import metaconfigure
-    metaconfigure  # pyflakes
-except ImportError:
-    from Products.Five.zcml import load_config
-    from Products.Five import fiveconfigure as metaconfigure
 
-
-class IntegrationLayer(PloneSite):
+class IntegrationFixture(PloneSandboxLayer):
     """ layer for integration tests using the folder replacement type """
 
-    @classmethod
-    def setUp(cls):
-        root = app()
-        portal = root.plone
-        # load zcml & install the package
-        metaconfigure.debug_mode = True
+    defaultBases = (PTC_FUNCTIONAL_TESTING,)
+
+    def setUpZope(self, app, configurationContext):
         from plone.app.folder import tests
-        load_config('testing.zcml', tests)
-        metaconfigure.debug_mode = False
-        installPackage('plone.app.folder', quiet=True)
-        # import replacement profile
-        profile = 'profile-plone.app.folder:default'
-        tool = getToolByName(portal, 'portal_setup')
-        tool.runAllImportStepsFromProfile(profile, purge_old=False)
-        # make sure it's loaded...
+        self.loadZCML('testing.zcml', package=tests)
+
+    def setUpPloneSite(self, portal):
+        # restore default workflow
+        applyProfile(portal, 'plone.app.folder:default')
+
         types = getToolByName(portal, 'portal_types')
         assert types.getTypeInfo('Folder').product == 'plone.app.folder'
-        # and commit the changes
-        commit()
-        close(root)
-
-    @classmethod
-    def tearDown(cls):
-        pass
 
 
-class PartialOrderingIntegrationLayer(IntegrationLayer):
+PAF_INTEGRATION_FIXTURE = IntegrationFixture()
+IntegrationLayer = FunctionalTesting(
+    bases=(PAF_INTEGRATION_FIXTURE,), name='plone.app.folder testing:Integration')
+
+
+class PartialOrderingIntegrationFixture(IntegrationFixture):
     """ layer for integration tests using the partial ordering adapter """
 
-    @classmethod
-    def setUp(cls):
+    def setUpZope(self, app, configurationContext):
+        IntegrationFixture.setUpZope(self, app, configurationContext)
         provideAdapter(PartialOrdering)
 
-    @classmethod
-    def tearDown(cls):
-        pass
+
+PAF_ORDERING_FIXTURE = PartialOrderingIntegrationFixture()
+PartialOrderingIntegrationLayer = FunctionalTesting(
+    bases=(PAF_ORDERING_FIXTURE,), name='plone.app.folder testing:Partial ordering integration')

--- a/src/plone/app/folder/tests/test_integration.py
+++ b/src/plone/app/folder/tests/test_integration.py
@@ -28,7 +28,3 @@ class FolderReplacementTests(IntegrationTestCase):
                 GopipIndex
             )
         )
-
-
-def test_suite():
-    return defaultTestLoader.loadTestsFromName(__name__)

--- a/src/plone/app/folder/tests/test_migration.py
+++ b/src/plone/app/folder/tests/test_migration.py
@@ -238,7 +238,3 @@ class TestBTreeMigration(IntegrationTestCase):
         self.failUnless(isSaneBTreeFolder(self.portal.test.foo))
         self.failUnless(isSaneBTreeFolder(self.portal.test.bar))
 
-
-def test_suite():
-    from unittest import defaultTestLoader
-    return defaultTestLoader.loadTestsFromName(__name__)

--- a/src/plone/app/folder/tests/test_nextprevious.py
+++ b/src/plone/app/folder/tests/test_nextprevious.py
@@ -148,7 +148,3 @@ class NextPreviousSupportTests(IntegrationTestCase):
         previous = adapter.getPreviousItem(container.subDoc2)
         self.assertEqual(previous, None)
 
-
-def test_suite():
-    from unittest import defaultTestLoader
-    return defaultTestLoader.loadTestsFromName(__name__)

--- a/src/plone/app/folder/tests/test_nogopip.py
+++ b/src/plone/app/folder/tests/test_nogopip.py
@@ -1,4 +1,3 @@
-from unittest import defaultTestLoader
 from plone.app.folder.tests.base import IntegrationTestCase
 from plone.app.folder.tests.content import UnorderedFolder
 from plone.app.folder.tests.layer import IntegrationLayer
@@ -62,6 +61,3 @@ class NoGopipTests(IntegrationTestCase):
         self.assertEqual(ids,
             ['bar5', 'bar7', 'bar6', 'bar2', 'bar1', 'bar3', 'bar4'])
 
-
-def test_suite():
-    return defaultTestLoader.loadTestsFromName(__name__)

--- a/src/plone/app/folder/tests/test_partialordering_integration.py
+++ b/src/plone/app/folder/tests/test_partialordering_integration.py
@@ -3,7 +3,6 @@ from Products.ATContentTypes.content.document import ATDocument
 from plone.app.folder.tests.base import IntegrationTestCase
 from plone.app.folder.tests.layer import PartialOrderingIntegrationLayer
 from plone.folder.interfaces import IOrderable
-from unittest import defaultTestLoader
 from zope.interface import classImplements
 
 
@@ -46,7 +45,3 @@ class PartialOrderingTests(IntegrationTestCase):
         self.assertEqual(self.folder.getObjectPosition('bar'), 1)
         self.folder.invokeFactory('Event', id='party')
         self.assertEqual(self.folder.getObjectPosition('party'), None)
-
-
-def test_suite():
-    return defaultTestLoader.loadTestsFromName(__name__)

--- a/src/plone/app/folder/tests/test_unorderedordering_integration.py
+++ b/src/plone/app/folder/tests/test_unorderedordering_integration.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.app.folder.tests.base import IntegrationTestCase
 from plone.app.folder.tests.layer import IntegrationLayer
-from unittest import defaultTestLoader
 
 
 class UnorderedOrderingTests(IntegrationTestCase):
@@ -36,6 +35,3 @@ class UnorderedOrderingTests(IntegrationTestCase):
         self.assertEqual(container.getObjectPosition('o1'), None)
         self.assertEqual(container.getObjectPosition('o2'), None)
 
-
-def test_suite():
-    return defaultTestLoader.loadTestsFromName(__name__)

--- a/src/plone/app/folder/tests/test_utils.py
+++ b/src/plone/app/folder/tests/test_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from Testing import ZopeTestCase as ztc
 from plone.app.folder.utils import findObjects
-from unittest import defaultTestLoader, main
 
 
 class UtilsTests(ztc.ZopeTestCase):
@@ -35,10 +34,3 @@ class UtilsTests(ztc.ZopeTestCase):
         self.assertEqual(found[0], ('', self.portal))
         # but the rest should be the same...
         self.assertEqual(self.ids(found[1:]), self.good)
-
-
-def test_suite():
-    return defaultTestLoader.loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    main(defaultTest='test_suite')


### PR DESCRIPTION
Reverts plone/plone.app.folder#4

Tests were failing for Plone 5 AT job.

Failing tests: http://jenkins.plone.org/job/plone-5.0-python-2.7-at/3592/testReport/
Once removed tests no longer fail: http://jenkins.plone.org/job/plone-5.0-python-2.7-at/3593/testReport

As there were other errors in other packages, maybe is due to them, so let's wait until the jobs is green again and try to merge once again.
