### PR TITLE
Restore orignal __repr__ 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,10 +17,13 @@ Bug fixes:
 
 - fix testisolation problems
   [petschki]
-  
+
 - Switch to new TestCase using AT after PloneTestcase is now DX.
   [pbauer]
 
+- Restore orignal __repr__ by adding OFS.SimpleItem.PathReprProvider as a baseclass to ATFolder
+  See https://github.com/plone/Products.CMFPlone/issues/2590
+  [pbauer]
 
 1.2.6 (2018-09-23)
 ------------------

--- a/src/plone/app/folder/folder.py
+++ b/src/plone/app/folder/folder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import ClassSecurityInfo
+from OFS.SimpleItem import PathReprProvider
 from Products.ATContentTypes.content.base import ATCTFolderMixin
 from Products.ATContentTypes.content.base import registerATCT
 from Products.ATContentTypes.content.schemata import ATContentTypeSchema
@@ -24,7 +25,7 @@ class IATUnifiedFolder(IATFolder):
 
 
 @implementer(IATUnifiedFolder, IATBTreeFolder)
-class ATFolder(ATCTFolderMixin, BaseBTreeFolder):
+class ATFolder(PathReprProvider, ATCTFolderMixin, BaseBTreeFolder):
     """ a folder suitable for holding a very large number of items """
 
     schema = ATFolderSchema


### PR DESCRIPTION
adds PathReprProvider as baseclass to ATFolder. 
See https://github.com/plone/Products.CMFPlone/issues/2590