### PR TITLE
Speedup Large Navtree Rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,10 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fixes slow lookup of documentToKeyMap in GopipIndex.
+  About 66x speedup.
+  This may add up to seconds less on large navtree renderings.
+  [jensens]
 
 
 1.1.2 (2015-10-27)

--- a/src/plone/app/folder/nogopip.py
+++ b/src/plone/app/folder/nogopip.py
@@ -12,6 +12,24 @@ from zope.interface import implementer
 logger = getLogger(__name__)
 
 
+def traverse(base, path):
+    """simplified fast unrestricted traverse.
+
+    base: the root to start from
+    path: absolute path from app root as string
+    returns: content at the end or None
+    """
+    current = base
+    for cid in path.split('/'):
+        if not cid:
+            continue
+        try:
+            current = current[cid]
+        except KeyError:
+            return None
+    return current
+
+
 @implementer(IPluggableIndex)
 class StubIndex(SimpleItem):
     """ stub catalog index doing nothing """
@@ -74,13 +92,13 @@ class GopipIndex(StubIndex):
         items = []
         containers = {}
         getpath = self.catalog.paths.get
-        traverse = getUtility(ISiteRoot).unrestrictedTraverse
+        root = getUtility(ISiteRoot).getPhysicalRoot()
         for rid in rs:
             path = getpath(rid)
             parent, id = path.rsplit('/', 1)
             container = containers.get(parent)
             if container is None:
-                containers[parent] = container = traverse(parent)
+                containers[parent] = container = traverse(root, parent)
             rids[id] = rid              # remember in case of single folder
             items.append((rid, container, id))  # or else for deferred lookup
         pos = {}


### PR DESCRIPTION
Fixes slow lookup of paths in ``documentToKeyMap`` in GopipIndex.
About 66x speedup.
This may add up to seconds less on large navtree renderings

Profiling before:
![Screenshot at 2019-08-13 21-52-44](https://user-images.githubusercontent.com/157140/62980093-dc43a980-be25-11e9-9e0e-aeb42a3a1bc8.png)

Profiling after:
![Screenshot at 2019-08-13 22-09-00](https://user-images.githubusercontent.com/157140/62980102-e4034e00-be25-11e9-9aa4-455daa677b88.png)
